### PR TITLE
Add support for `nodeSelector` and `tolerations` to Helm chart values

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -62,3 +62,11 @@ spec:
               cpu: 100m
               memory: 128Mi
       serviceAccountName: "{{ .Release.Name }}-server"
+      {{- with .Values.deployment.nodeSelector }}
+      nodeSelector:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/chart/values.example.yaml
+++ b/chart/values.example.yaml
@@ -15,3 +15,11 @@ security:
     secretName: k8s-secret-holding-your-SUPER-SECRET-key-for-hashing
     key: key-in-the-k8s-secret-containing-the-ACTUAL-HASHING-SECRET
   allowedDomains: [example.com]
+deployment:
+  nodeSelector:
+    a: b
+  tolerations:
+    - key: TaintKey
+      operator: Equal
+      value: TaintValue
+      effect: NoSchedule

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3,6 +3,39 @@
   "type": "object",
   "required": ["oauth", "security"],
   "properties": {
+    "deployment": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "nodeSelector": {
+          "type": "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "tolerations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "operator": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              },
+              "effect": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
     "oauth": {
       "type": "object",
       "required": ["clientId", "clientSecret", "host"],

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -15,3 +15,6 @@
 #    secretName: ""
 #    key: ""
 #  allowedDomains: []
+#deployment:
+#  nodeSelector: {}
+#  toletions: []


### PR DESCRIPTION
This change allows Helm consumers to specify the deployment's `nodeSelector` and `tolerations`.