### PR TITLE
FEAT: Add support for adding annotations on generated service account

### DIFF
--- a/chart/templates/service-account.yaml
+++ b/chart/templates/service-account.yaml
@@ -1,6 +1,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  {{- if .Values.serviceAccount }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+  {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- end }}
   labels:
     app: "{{.Release.Name}}"
     app.kubernetes.io/component: server

--- a/chart/values.example.yaml
+++ b/chart/values.example.yaml
@@ -23,3 +23,6 @@ deployment:
       operator: Equal
       value: TaintValue
       effect: NoSchedule
+serviceAccount:
+  annotations:
+    a: b

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3,6 +3,17 @@
   "type": "object",
   "required": ["oauth", "security"],
   "properties": {
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "deployment": {
       "type": "object",
       "required": [],

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -18,3 +18,6 @@
 #deployment:
 #  nodeSelector: {}
 #  toletions: []
+#serviceAccount:
+#  annotations:
+#    a: b


### PR DESCRIPTION
Useful for integrating this plugin with GCP Workload Identity.